### PR TITLE
Use kernel 6.6 as latest LTS release

### DIFF
--- a/conf/linux-mainline/lts.inc
+++ b/conf/linux-mainline/lts.inc
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT
 
 require conf/linux-mainline/stable.inc
-PREFERRED_VERSION_linux-stable = "6.1%"
+PREFERRED_VERSION_linux-stable = "6.6%"

--- a/kas/kernel-6.6.yml
+++ b/kas/kernel-6.6.yml
@@ -1,0 +1,10 @@
+# Copyright (C) 2023, meta-linux-mainline contributors
+# SPDX-License-Identifier: MIT
+
+header:
+  version: 9
+
+local_conf_header:
+  kernel-version: |
+    require conf/linux-mainline/stable.inc
+    PREFERRED_VERSION_linux-stable = "6.6%"


### PR DESCRIPTION
* Update `conf/linux-mainline/lts.inc` to refer to the new official LTS release
* Add `kas/kernel-6.6.yml` to select the 6.6 release explicitly